### PR TITLE
Adding Skip Redirect, Replacing ClearURLs, removing HTTPS everywhere and mpc-hc

### DIFF
--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -296,7 +296,7 @@
 
 - Media Player
 
-    - [mpv](https://mpv.io) recommended
+    - [mpv](https://mpv.io) or [mpc-hc](https://mpc-hc.org) ([alternative link](https://github.com/clsid2/mpc-hc)) recommended
 
 - Install [OpenShell](https://github.com/Open-Shell/Open-Shell-Menu)
 

--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -296,9 +296,7 @@
 
 - Media Player
 
-    - [mpv](https://mpv.io) or [mpc-hc](https://mpc-hc.org) recommended
-
-        - Delete ``C:\Program Files\MPC-HC\crashreporter`` if using mpc-hc
+    - [mpv](https://mpv.io) recommended
 
 - Install [OpenShell](https://github.com/Open-Shell/Open-Shell-Menu)
 
@@ -851,7 +849,7 @@ issues [[1](https://repo.zenk-security.com/Linux%20et%20systemes%20d.exploitatio
 
 - Try to favour FOSS (free & open source software). Stay away from proprietary software where you can.
 
-- You do not need an antivirus. You need a brain & uBlock origin in your browser, i also recommend installing ClearURL & https everywhere extensions. Ensure to scan files with [VirusTotal](https://www.virustotal.com/gui/home/upload) before running them.
+- You do not need an antivirus. You need a brain & uBlock origin in your browser. I also recommend importing [ClearURL Filter List](https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ClearURLs%20for%20uBo/clear_urls_uboified.txt) into uBlock origin & installing the [Skip Redirect](https://addons.mozilla.org/firefox/addon/skip-redirect/) extension. Ensure to scan files with [VirusTotal](https://www.virustotal.com/gui/home/upload) before running them.
 
 - Cap your framerate at a multiple of your monitor refresh rate to prevent frame mistiming [[1](https://youtu.be/_73gFgNrYVQ)]. E.g possible framerate caps with a 144hz monitor include 72, 144, 288, 432 ...
 


### PR DESCRIPTION
- Replaced ClearURLs extension with the ClearURLs fitler list as it reduces the need for another extension, leading to a better browser fingerprint. 
- Removed HTTPS everywhere since HTTPS for all windows is enabled by default in librewolf.
- [mpc-hc has not been in development since 2017. ](https://mpc-hc.org/2017/07/16/1.7.13-released-and-farewell/)
- Adding Skip Redirect since it is recommended by [Arkenfox user.js](https://github.com/arkenfox/user.js/wiki/4.1-Extensions)