### PR TITLE
disable startup delay for windows 10

### DIFF
--- a/prerequisites/scripts/registry/10+.reg
+++ b/prerequisites/scripts/registry/10+.reg
@@ -54,3 +54,8 @@ Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DiagTrack]
 "Start"=dword:00000004
+
+; disable startup delay
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize]
+"StartupDelayInMSec"=dword:00000000

--- a/prerequisites/scripts/registry/10+.reg
+++ b/prerequisites/scripts/registry/10+.reg
@@ -55,7 +55,7 @@ Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DiagTrack]
 "Start"=dword:00000004
 
-; disable startup delay
+; disable autostart delay
 
-[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize]
+[HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Serialize]
 "StartupDelayInMSec"=dword:00000000


### PR DESCRIPTION
Exist in Windows 10+. 
Before introduced in Windows Vista, was disabled in Windows 7 and Windows 8 by default, was named "Delay_Sec" in  HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced\DelayedApps.

More info:
https://winaero.com/speed-up-your-windows-startup-with-these-tricks/ https://winaero.com/speed-up-the-startup-of-desktop-apps-in-windows-10/