### PR TITLE
remove storage and cpu checks for w11

### DIFF
--- a/bypass-windows11-checks.reg
+++ b/bypass-windows11-checks.reg
@@ -4,5 +4,3 @@
 "BypassTPMCheck"=dword:00000001
 "BypassRAMCheck"=dword:00000001
 "BypassSecureBootCheck"=dword:00000001
-"BypassCPUCheck"=dword:00000001
-"BypassStorageCheck"=dword:00000001


### PR DESCRIPTION
>But the two other settings, BypassCPUCheck and BypassStorageCheck, don’t appear to exist. If we take that premise a bit further and search all of the Setup binaries for the “LabConfig” registry key and “Bypass” values, using strings.exe to parse the binaries looking for that text, you can see that only the previous three settings actually exist:

https://oofhours.com/2022/07/25/bypassing-windows-11-hardware-requirements-revisited